### PR TITLE
feat: platform dependent UI

### DIFF
--- a/express-client/src/index.ts
+++ b/express-client/src/index.ts
@@ -5,3 +5,4 @@
 export { BeagleApp } from './beagle-app'
 export { Screen, ScreenRequest } from './screen'
 export { RouteMap } from './route'
+export { isMobile, isWeb } from './utils/headers'

--- a/express-client/src/screen.ts
+++ b/express-client/src/screen.ts
@@ -1,14 +1,14 @@
 import { Request, Response } from 'express'
 import { WithAnalytics, Context, Component, DeepExpression } from '@zup-it/beagle-backend-core'
 import { Navigator } from './navigator'
-import { IsRequired } from './utils/types'
+import { BeagleHeaders, IsRequired } from './utils/types'
 
 export interface RequestWithCustomHeaders<RouteParams = any, Headers = any, Body = any, Query = any>
   extends Request<RouteParams, any, Body, Query> {
   /**
    * The request headers of the request.
    */
-  headers: Request['headers'] & Headers,
+  headers: Request['headers'] & Headers & BeagleHeaders,
 }
 
 /**

--- a/express-client/src/utils/headers.ts
+++ b/express-client/src/utils/headers.ts
@@ -1,0 +1,71 @@
+import { BeagleHeaders } from './types'
+
+/**
+ * Verifies if the frontend is a web application.
+ *
+ * @example
+ * ```tsx
+ * const MyScreen: Screen = ({ request: { headers } }) => {
+ *   const content = (
+ *     <>
+ *       <Text>This is the common content between all platforms</Text>
+ *       <Button>Ok!</Button>
+ *     </>
+ *   )
+ *
+ *   return isWeb(headers) ? (
+ *     <Container style={{ flexDirection: 'ROW' }}>
+ *       <Image type="remote" url="https://imagebank/logo.png" style={ { marginRight: 10 } } />
+ *       {content}
+ *     </Container>
+ *   ) : (
+ *     <>
+ *       <Image type="local" url="logo" style={ { marginBottom: 10 } } />
+ *       {content}
+ *     </>
+ *   )
+ * }
+ * ```
+ * Now, the screen will be different based on the platform that requested it.
+ *
+ * @param headers the headers received by the screen.
+ * @returns true if it is a web application, false otherwise.
+ */
+export function isWeb(headers: BeagleHeaders): boolean {
+  return headers['beagle-platform'] === 'WEB'
+}
+
+/**
+ * Verifies if the frontend is a mobile application.
+ *
+ * @example
+ * ```tsx
+ * const MyScreen: Screen = ({ request: { headers } }) => {
+ *   const content = (
+ *     <>
+ *       <Text>This is the common content between all platforms</Text>
+ *       <Button>Ok!</Button>
+ *     </>
+ *   )
+ *
+ *   return isMobile(headers) ? (
+ *     <>
+ *       <Image type="local" url="logo" style={ { marginBottom: 10 } } />
+ *       {content}
+ *     </>
+ *   ) : (
+ *     <Container style={{ flexDirection: 'ROW' }}>
+ *       <Image type="remote" url="https://imagebank/logo.png" style={ { marginRight: 10 } } />
+ *       {content}
+ *     </Container>
+ *   )
+ * }
+ * ```
+ * Now, the screen will be different based on the platform that requested it.
+ *
+ * @param headers the headers received by the screen.
+ * @returns true if it is a mobile application, false otherwise.
+ */
+export function isMobile(headers: BeagleHeaders): boolean {
+  return headers['beagle-platform'] === 'MOBILE'
+}

--- a/express-client/src/utils/types.ts
+++ b/express-client/src/utils/types.ts
@@ -1,3 +1,7 @@
+export interface BeagleHeaders {
+  'beagle-platform'?: 'WEB' | 'MOBILE',
+}
+
 export type IsRequired<T extends object, K extends keyof T> = T extends Record<K, T[K]> ? true : false
 
 export type HasRequiredProperty<T extends object> =


### PR DESCRIPTION
Implements the feature of the BFF Kotlin where the dev can decide which UI to use depending on the platform that requested the screen.

Docs: https://github.com/ZupIT/beagle-backend-ts/wiki/Giving-a-type-to-your-screens#deciding-which-components-to-use-based-on-the-platform