### PR TITLE
fix: Validation of ID on local navigations

### DIFF
--- a/cli/src/commands/generate-screen/screen.ts
+++ b/cli/src/commands/generate-screen/screen.ts
@@ -1,13 +1,13 @@
 import path from 'path'
 import fsPromise from 'fs/promises'
-import lodash from 'lodash'
+import { camelCase } from 'lodash'
 import { pathExists } from 'fs-extra'
 import { logger } from '../../utils'
 import { BeagleTsConfig } from '../types'
 import { GenerateScreenOptions } from './types'
 
 export const generateScreenCodeFromBoilerplate = async (screenName: string, options: GenerateScreenOptions) => {
-  const formattedScreenName = lodash.camelCase(screenName)
+  const formattedScreenName = camelCase(screenName)
   const screenProps = {
     ...(options.withRouteParams ? { routeParams: { your: 'routeParams' } } : {}),
     ...(options.withHeaders ? { headers: { your: 'headers' } } : {}),
@@ -71,7 +71,7 @@ const getUpdatedRoutesFileCode = (
   configs: BeagleTsConfig,
 ) => {
   const varCodeBlock = routesFileContent.match(new RegExp(`${configs.routes.varName}.*?{([\\s\\S]*?)}`, 'gm'))
-  const formattedName = lodash.camelCase(screenName)
+  const formattedName = camelCase(screenName)
 
   if (varCodeBlock && varCodeBlock.length) {
     const routes = varCodeBlock[0].match(/'.*?':.*?[,|\n]/gm)

--- a/cli/src/templates/boilerplate/src/screens/welcome.tsx
+++ b/cli/src/templates/boilerplate/src/screens/welcome.tsx
@@ -17,7 +17,9 @@ export const Welcome: Screen = ({ navigator }) => (
     <Image type="remote" url="https://i.ibb.co/rvRN9kv/logo.png" style={{ width: 242, height: 225 }} />
     <Text style={{ marginTop: 40 }}>Welcome to the Beagle Backend with TypeScript!</Text>
     <Text style={{ marginTop: 5 }}>This is a boilerplate application, so you can modify as you want!</Text>
-    <Button style={{ marginTop: 40 }} onPress={globalContext.set({ message: 'I came from welcome page!' })}>Set Global Context</Button>
+    <Button style={{ marginTop: 40 }} onPress={globalContext.set({ message: 'I came from welcome page!' })}>
+      Set Global Context
+    </Button>
     <Button style={{ marginTop: 40 }} onPress={navigator.pushView(Home)}>Navigate to Home Page</Button>
   </Container>
 )

--- a/core/__tests__/actions/navigation.spec.ts
+++ b/core/__tests__/actions/navigation.spec.ts
@@ -170,16 +170,23 @@ describe('Actions: navigation', () => {
       analytics,
     ))
 
-    it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
-      expectActionToBeCorrect(pushStack(localRouteProps), 'pushStack', localRouteProps)
-    })
-
     it('should create action with only route', () => expectActionToBeCorrect(
       pushStack('test'),
       'pushStack',
       { route: { url: 'test' } },
     ))
+
+    describe('local route', () => {
+      it('should create action', () => {
+        const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
+        expectActionToBeCorrect(pushStack(localRouteProps), 'pushStack', localRouteProps)
+      })
+
+      it('should throw when an id is not provided', () => {
+        const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+        expect(() => pushStack(localRouteProps)).toThrow()
+      })
+    })
   })
 
   describe('pushView', () => {
@@ -205,16 +212,23 @@ describe('Actions: navigation', () => {
       analytics,
     ))
 
-    it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
-      expectActionToBeCorrect(pushView(localRouteProps), 'pushView', localRouteProps)
-    })
-
     it('should create action with only route', () => expectActionToBeCorrect(
       pushView('test'),
       'pushView',
       { route: { url: 'test' } },
     ))
+
+    describe('local route', () => {
+      it('should create action with', () => {
+        const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
+        expectActionToBeCorrect(pushView(localRouteProps), 'pushView', localRouteProps)
+      })
+
+      it('should throw when an id is not provided', () => {
+        const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+        expect(() => pushView(localRouteProps)).toThrow()
+      })
+    })
   })
 
   describe('resetApplication', () => {
@@ -241,16 +255,23 @@ describe('Actions: navigation', () => {
       analytics,
     ))
 
-    it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
-      expectActionToBeCorrect(resetApplication(localRouteProps), 'resetApplication', localRouteProps)
-    })
-
     it('should create action with only route', () => expectActionToBeCorrect(
       resetApplication('test'),
       'resetApplication',
       { route: { url: 'test' } },
     ))
+
+    describe('local route', () => {
+      it('should create action', () => {
+        const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
+        expectActionToBeCorrect(resetApplication(localRouteProps), 'resetApplication', localRouteProps)
+      })
+
+      it('should throw when an id is not provided', () => {
+        const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+        expect(() => resetApplication(localRouteProps)).toThrow()
+      })
+    })
   })
 
   describe('resetStack', () => {
@@ -277,15 +298,22 @@ describe('Actions: navigation', () => {
       analytics,
     ))
 
-    it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
-      expectActionToBeCorrect(resetStack(localRouteProps), 'resetStack', localRouteProps)
-    })
-
     it('should create action with only route', () => expectActionToBeCorrect(
       resetStack('test'),
       'resetStack',
       { route: { url: 'test' } },
     ))
+
+    describe('local route', () => {
+      it('should create action with', () => {
+        const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
+        expectActionToBeCorrect(resetStack(localRouteProps), 'resetStack', localRouteProps)
+      })
+
+      it('should throw when an id is not provided', () => {
+        const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+        expect(() => resetStack(localRouteProps)).toThrow()
+      })
+    })
   })
 })

--- a/core/__tests__/actions/navigation.spec.ts
+++ b/core/__tests__/actions/navigation.spec.ts
@@ -171,7 +171,7 @@ describe('Actions: navigation', () => {
     ))
 
     it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
       expectActionToBeCorrect(pushStack(localRouteProps), 'pushStack', localRouteProps)
     })
 
@@ -206,7 +206,7 @@ describe('Actions: navigation', () => {
     ))
 
     it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
       expectActionToBeCorrect(pushView(localRouteProps), 'pushView', localRouteProps)
     })
 
@@ -242,7 +242,7 @@ describe('Actions: navigation', () => {
     ))
 
     it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
       expectActionToBeCorrect(resetApplication(localRouteProps), 'resetApplication', localRouteProps)
     })
 
@@ -278,7 +278,7 @@ describe('Actions: navigation', () => {
     ))
 
     it('should create action with local route', () => {
-      const localRouteProps = { route: { screen: new Component({ name: 'screen' }) } }
+      const localRouteProps = { route: { screen: new Component({ id: 'test-screen', name: 'screen' }) } }
       expectActionToBeCorrect(resetStack(localRouteProps), 'resetStack', localRouteProps)
     })
 

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -194,64 +194,63 @@ const navigator = {
   resetApplication: createCoreAction<ResetApplicationParams>('resetApplication'),
 }
 
-type AnyFunction = (...args: any) => any
-type NavigationFunctionParams<T, N extends AnyFunction, R> = T extends string ? R : Parameters<N>
-type NavigationFunctionReturnType<T, N extends AnyFunction> = T extends string ? Action : ReturnType<N>
-
 interface PushViewFunction {
   /**
    * Adds the provided route to the current navigation stack.
    *
-   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
-   * @returns an instance of Action
-   *
-   * @type {(props: ActionProps<PushViewParams>) => Action}
-   * @param props the parameters for  this navigation:
-   * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
-   * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @returns an instance of Action
+   * @return an instance of Action
    */
-  <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.pushView, [url: Expression<T>]>
-  ): NavigationFunctionReturnType<T, typeof navigator.pushView>,
+  (url: Expression<string>): Action,
+
+  /**
+   * Adds the provided route to the current navigation stack.
+   *
+   * @param props the parameters for  this navigation:
+   * - route the screen to load. A {@link LocalView} or a {@link RemoteView}.
+   * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
+   * @return an instance of Action
+   */
+  (...args: Parameters<typeof navigator.pushView>): ReturnType<typeof navigator.pushView>,
 }
 
 interface PushStackFunction {
   /**
    * Adds a new stack to the navigator with the provided route.
    *
-   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
-   * @returns an instance of Action
+   * @return an instance of Action
+   */
+   (url: Expression<string>): Action,
+
+  /**
+   * Adds a new stack to the navigator with the provided route.
    *
-   * @type {(props: ActionProps<PushStackParams>) => Action}
    * @param props the parameters for this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @returns an instance of Action
+   * @return an instance of Action
    */
-  <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.pushStack, [url: Expression<T>]>
-  ): NavigationFunctionReturnType<T, typeof navigator.pushStack>,
+  (...args: Parameters<typeof navigator.pushStack>): ReturnType<typeof navigator.pushStack>,
 }
 
 interface PopStackFunction {
   /**
    * Pops the current stack, going back to the last route of the previous stack.
    *
-   * @type {() => Action}
-   * @returns an instance of Action
-   *
-   * @type {(props: ActionProps<PopStackParams>) => Action}
    * @param props the parameters for this navigation:
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @returns an instance of Action
+   * @return an instance of Action
    */
-   <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.popStack, []>
-  ): NavigationFunctionReturnType<T, typeof navigator.popStack>,
+   (...args: Parameters<typeof navigator.popStack>): ReturnType<typeof navigator.popStack>,
+
+  /**
+   * Pops the current stack, going back to the last route of the previous stack.
+   *
+   * @return an instance of Action
+   * */
+   (): Action,
 }
 
 interface PopToViewFunction {
@@ -259,77 +258,82 @@ interface PopToViewFunction {
    * Goes back to the route identified by the string passed as parameter. If the route doesn't exist in the current
    * navigation stack, nothing happens.
    *
-   * @type {(routeId: Expression<string>) => Action}
-   * @param routeId the identifier of the route to go back to. For RemoteViews, this identifier will be the url. For
-   * LocalViews, it will the id of the root component.
-   * @returns an instance of Action
+   * @param routeId the identifier of the route to go back to. For RemoteViews, this identifier
+   * will be the url. For LocalViews, it will the id of the root component.
+   * @return an instance of Action
+   */
+   (routeId: Expression<string>): Action,
+
+  /**
+   * Goes back to the route identified by the string passed as parameter. If the route doesn't exist in the current
+   * navigation stack, nothing happens.
    *
-   * @type {(props: ActionProps<PopToViewParams>) => Action}
    * @param props the parameters for this navigation:
    * - route: the identifier for the screen to go back to.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @returns an instance of Action
+   * @return an instance of Action
    */
-  <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.popToView, [routeId: Expression<T>]>
-  ): NavigationFunctionReturnType<T, typeof navigator.popToView>,
+  (...args: Parameters<typeof navigator.popToView>): ReturnType<typeof navigator.popToView>,
 }
 
 interface ResetStackFunction {
   /**
    * Removes the current navigation stack and adds a new one with the provided route.
    *
-   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
-   * @returns an instance of Action
+   * @return an instance of Action
+   */
+  (url: Expression<string>): Action,
+
+  /**
+   * Removes the current navigation stack and adds a new one with the provided route.
    *
-   * @type {(props: ActionProps<ResetStackParams>) => Action}
    * @param props the parameters for this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.resetStack, [url: Expression<T>]>
-  ): NavigationFunctionReturnType<T, typeof navigator.resetStack>,
+  (...args: Parameters<typeof navigator.resetStack>): ReturnType<typeof navigator.resetStack>,
 }
 
 interface PopViewFunction {
   /**
    * Goes back to the previous route.
    *
-   * @type {() => Action}
-   * @returns an instance of Action
-   *
-   * @type {(props: ActionProps<PopViewParams>) => Action}
    * @param props the parameters for this navigation:
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.popView, []>
-  ): NavigationFunctionReturnType<T, typeof navigator.popView>,
+  (...args: Parameters<typeof navigator.popView>): ReturnType<typeof navigator.popView>,
+
+  /**
+   * Goes back to the previous route.
+   *
+   * @returns an instance of Action
+   * */
+  (): Action,
 }
 
 interface ResetApplicationFunction {
   /**
    * Removes all the navigation stacks and adds a new one with the provided route.
    *
-   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
-   * @returns an instance of Action
+   * @return an instance of Action
+   */
+   (url: Expression<string>): Action,
+
+  /**
+   * Removes all the navigation stacks and adds a new one with the provided route.
    *
-   * @type {(props: ActionProps<ResetApplicationParams>) => Action}
    * @param props the parameters for this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  <T>(
-    ...args: NavigationFunctionParams<T, typeof navigator.resetApplication, [url: Expression<T>]>
-  ): NavigationFunctionReturnType<T, typeof navigator.resetApplication>,
+  (...args: Parameters<typeof navigator.resetApplication>): ReturnType<typeof navigator.resetApplication>,
 }
 
 function validateLocalNavigationScreen(screen: Component | (() => Component)): void {
@@ -341,6 +345,7 @@ function validateLocalNavigationScreen(screen: Component | (() => Component)): v
 
 function validateLocalNavigationOptions(options: any) {
   if (!options.route) throw new Error('The "route" property is mandatory to perform a local navigation.')
+  if (typeof options.route === 'string' || options.route.url) return
   if (!options.route.screen) throw new Error('The "route.screen" property is mandatory to perform a local navigation.')
   if (options.route.screen instanceof Component || typeof options.route.screen === 'function') {
     validateLocalNavigationScreen(options.route.screen)
@@ -348,27 +353,28 @@ function validateLocalNavigationOptions(options: any) {
   else throw new Error('The "route.screen" property must be a Component or a RemoteView.')
 }
 
-function getParams(options: any, isPopToView = false) {
-  const isParamASingleUrl = typeof options === 'string' || isDynamicExpression(options)
-  if (isParamASingleUrl) return { route: isPopToView ? options : { url: options } }
-  const { navigationContext, ...other } = options
-  validateLocalNavigationOptions(options)
+type GetParamsOptions = { isPopToView?: boolean, routeless?: boolean }
+
+function getParams(props: any, options?: GetParamsOptions) {
+  const isParamASingleUrl = typeof props === 'string' || isDynamicExpression(props)
+  if (isParamASingleUrl) return { route: options?.isPopToView ? props : { url: props } }
+
+  const { navigationContext, ...other } = props
+  if (!options?.routeless) validateLocalNavigationOptions(props)
   return { navigationContext: formatNavigationContext(navigationContext), ...other }
 }
 
 /** @category Actions */
-export const pushView: PushViewFunction = (options) => navigator.pushView(getParams(options))
+export const pushView: PushViewFunction = (props) => navigator.pushView(getParams(props))
 /** @category Actions */
-export const pushStack: PushStackFunction = (options) => navigator.pushStack(getParams(options))
+export const pushStack: PushStackFunction = (props) => navigator.pushStack(getParams(props))
 /** @category Actions */
-export const resetStack: ResetStackFunction = (options) => navigator.resetStack(getParams(options))
+export const resetStack: ResetStackFunction = (props) => navigator.resetStack(getParams(props))
 /** @category Actions */
-export const resetApplication: ResetApplicationFunction = (options) => (
-  navigator.resetApplication(getParams(options))
-)
+export const resetApplication: ResetApplicationFunction = (props) => (navigator.resetApplication(getParams(props)))
 /** @category Actions */
-export const popToView: PopToViewFunction = (options) => navigator.popToView(getParams(options, true))
+export const popToView: PopToViewFunction = (props) => navigator.popToView(getParams(props, { isPopToView: true }))
 /** @category Actions */
-export const popView: PopViewFunction = (options = {}) => navigator.popView(getParams(options))
+export const popView: PopViewFunction = (props = {}) => navigator.popView(getParams(props, { routeless: true }))
 /** @category Actions */
-export const popStack: PopStackFunction = (options = {}) => navigator.popStack(getParams(options))
+export const popStack: PopStackFunction = (props = {}) => navigator.popStack(getParams(props, { routeless: true }))

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -158,7 +158,7 @@ export interface BaseNavigationParams {
 
 export interface RouteNavigationParams<T extends (Route | string) = Route> extends BaseNavigationParams {
   /**
-   * The route to navigate to. It can be either a remote view, fetched from the backend, ou a local view, which is
+   * The route to navigate to. It can be either a remote view, fetched from the backend, or a local view, which is
    * just a new component tree. When it's local, the root of the tree must have an id, this will be used as the name
    * of the route in the local navigator.
    */
@@ -194,60 +194,64 @@ const navigator = {
   resetApplication: createCoreAction<ResetApplicationParams>('resetApplication'),
 }
 
+type AnyFunction = (...args: any) => any
+type NavigationFunctionParams<T, N extends AnyFunction, R> = T extends string ? R : Parameters<N>
+type NavigationFunctionReturnType<T, N extends AnyFunction> = T extends string ? Action : ReturnType<N>
+
 interface PushViewFunction {
   /**
    * Adds the provided route to the current navigation stack.
    *
+   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
    * @returns an instance of Action
-   */
-  (url: Expression<string>): Action,
-  /**
-   * Adds the provided route to the current navigation stack.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<PushViewParams>) => Action}
+   * @param props the parameters for  this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  (...args: Parameters<typeof navigator.pushView>): ReturnType<typeof navigator.pushView>,
+  <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.pushView, [url: Expression<T>]>
+  ): NavigationFunctionReturnType<T, typeof navigator.pushView>,
 }
 
 interface PushStackFunction {
   /**
    * Adds a new stack to the navigator with the provided route.
    *
+   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
    * @returns an instance of Action
-   */
-  (url: Expression<string>): Action,
-  /**
-   * Adds a new stack to the navigator with the provided route.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<PushStackParams>) => Action}
+   * @param props the parameters for this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  (...args: Parameters<typeof navigator.pushStack>): ReturnType<typeof navigator.pushStack>,
+  <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.pushStack, [url: Expression<T>]>
+  ): NavigationFunctionReturnType<T, typeof navigator.pushStack>,
 }
 
 interface PopStackFunction {
   /**
    * Pops the current stack, going back to the last route of the previous stack.
    *
+   * @type {() => Action}
    * @returns an instance of Action
-   */
-   (): Action,
-  /**
-   * Pops the current stack, going back to the last route of the previous stack.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<PopStackParams>) => Action}
+   * @param props the parameters for this navigation:
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-   (...args: Parameters<typeof navigator.popStack>): ReturnType<typeof navigator.popStack>,
+   <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.popStack, []>
+  ): NavigationFunctionReturnType<T, typeof navigator.popStack>,
 }
 
 interface PopToViewFunction {
@@ -255,100 +259,116 @@ interface PopToViewFunction {
    * Goes back to the route identified by the string passed as parameter. If the route doesn't exist in the current
    * navigation stack, nothing happens.
    *
+   * @type {(routeId: Expression<string>) => Action}
    * @param routeId the identifier of the route to go back to. For RemoteViews, this identifier will be the url. For
    * LocalViews, it will the id of the root component.
    * @returns an instance of Action
-   */
-  (routeId: Expression<string>): Action,
-  /**
-   * Goes back to the route identified by the options passed as parameter (route). If the route doesn't exist in the
-   * current navigation stack, nothing happens.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<PopToViewParams>) => Action}
+   * @param props the parameters for this navigation:
    * - route: the identifier for the screen to go back to.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  (...args: Parameters<typeof navigator.popToView>): ReturnType<typeof navigator.popToView>,
+  <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.popToView, [routeId: Expression<T>]>
+  ): NavigationFunctionReturnType<T, typeof navigator.popToView>,
 }
 
 interface ResetStackFunction {
   /**
    * Removes the current navigation stack and adds a new one with the provided route.
    *
+   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
    * @returns an instance of Action
-   */
-  (url: Expression<string>): Action,
-  /**
-   * Removes the current navigation stack and adds a new one with the provided route.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<ResetStackParams>) => Action}
+   * @param props the parameters for this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  (...args: Parameters<typeof navigator.resetStack>): ReturnType<typeof navigator.resetStack>,
+  <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.resetStack, [url: Expression<T>]>
+  ): NavigationFunctionReturnType<T, typeof navigator.resetStack>,
 }
 
 interface PopViewFunction {
   /**
    * Goes back to the previous route.
    *
+   * @type {() => Action}
    * @returns an instance of Action
-   */
-  (): Action,
-  /**
-   * Goes back to the previous route.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<PopViewParams>) => Action}
+   * @param props the parameters for this navigation:
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  (...args: Parameters<typeof navigator.popView>): ReturnType<typeof navigator.popView>,
+  <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.popView, []>
+  ): NavigationFunctionReturnType<T, typeof navigator.popView>,
 }
 
 interface ResetApplicationFunction {
   /**
    * Removes all the navigation stacks and adds a new one with the provided route.
    *
+   * @type {(url: Expression<string>) => Action}
    * @param url the url to the screen to load
    * @returns an instance of Action
-   */
-  (url: Expression<string>): Action,
-  /**
-   * Removes all the navigation stacks and adds a new one with the provided route.
    *
-   * @param options the parameters for this navigation:
+   * @type {(props: ActionProps<ResetApplicationParams>) => Action}
+   * @param props the parameters for this navigation:
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
    */
-  (...args: Parameters<typeof navigator.resetApplication>): ReturnType<typeof navigator.resetApplication>,
+  <T>(
+    ...args: NavigationFunctionParams<T, typeof navigator.resetApplication, [url: Expression<T>]>
+  ): NavigationFunctionReturnType<T, typeof navigator.resetApplication>,
+}
+
+function validateLocalNavigationScreen(screen: Component | (() => Component)): void {
+  const component: Component = screen instanceof Component ? screen : screen()
+  if (!component.id) {
+    throw new Error(`The screen component must have an id, on the root component ("${component.namespace}:${component.name}"), to perform a local navigation.`)
+  }
+}
+
+function validateLocalNavigationOptions(options: any) {
+  if (!options.route) throw new Error('The "route" property is mandatory to perform a local navigation.')
+  if (!options.route.screen) throw new Error('The "route.screen" property is mandatory to perform a local navigation.')
+  if (options.route.screen instanceof Component || typeof options.route.screen === 'function') {
+    validateLocalNavigationScreen(options.route.screen)
+  }
+  else throw new Error('The "route.screen" property must be a Component or a RemoteView.')
 }
 
 function getParams(options: any, isPopToView = false) {
   const isParamASingleUrl = typeof options === 'string' || isDynamicExpression(options)
   if (isParamASingleUrl) return { route: isPopToView ? options : { url: options } }
   const { navigationContext, ...other } = options
+  validateLocalNavigationOptions(options)
   return { navigationContext: formatNavigationContext(navigationContext), ...other }
 }
 
 /** @category Actions */
-export const pushView: PushViewFunction = (options: any) => navigator.pushView(getParams(options))
+export const pushView: PushViewFunction = (options) => navigator.pushView(getParams(options))
 /** @category Actions */
-export const pushStack: PushStackFunction = (options: any) => navigator.pushStack(getParams(options))
+export const pushStack: PushStackFunction = (options) => navigator.pushStack(getParams(options))
 /** @category Actions */
-export const resetStack: ResetStackFunction = (options: any) => navigator.resetStack(getParams(options))
+export const resetStack: ResetStackFunction = (options) => navigator.resetStack(getParams(options))
 /** @category Actions */
-export const resetApplication: ResetApplicationFunction = (options: any) => (
+export const resetApplication: ResetApplicationFunction = (options) => (
   navigator.resetApplication(getParams(options))
 )
 /** @category Actions */
-export const popToView: PopToViewFunction = (options: any) => navigator.popToView(getParams(options, true))
+export const popToView: PopToViewFunction = (options) => navigator.popToView(getParams(options, true))
 /** @category Actions */
-export const popView: PopViewFunction = (options: any = {}) => navigator.popView(getParams(options))
+export const popView: PopViewFunction = (options = {}) => navigator.popView(getParams(options))
 /** @category Actions */
-export const popStack: PopStackFunction = (options: any = {}) => navigator.popStack(getParams(options))
+export const popStack: PopStackFunction = (options = {}) => navigator.popStack(getParams(options))

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -199,7 +199,7 @@ interface PushViewFunction {
    * Adds the provided route to the current navigation stack.
    *
    * @param url the url to the screen to load
-   * @return an instance of Action
+   * @returns an instance of Action
    */
   (url: Expression<string>): Action,
 
@@ -209,7 +209,7 @@ interface PushViewFunction {
    * @param props the parameters for  this navigation:
    * - route the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @return an instance of Action
+   * @returns an instance of Action
    */
   (...args: Parameters<typeof navigator.pushView>): ReturnType<typeof navigator.pushView>,
 }
@@ -219,7 +219,7 @@ interface PushStackFunction {
    * Adds a new stack to the navigator with the provided route.
    *
    * @param url the url to the screen to load
-   * @return an instance of Action
+   * @returns an instance of Action
    */
    (url: Expression<string>): Action,
 
@@ -230,7 +230,7 @@ interface PushStackFunction {
    * - route: the screen to load. A {@link LocalView} or a {@link RemoteView}.
    * - controllerId: the id for the navigation controller to use. See {@link StackNavigationParams}.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @return an instance of Action
+   * @returns an instance of Action
    */
   (...args: Parameters<typeof navigator.pushStack>): ReturnType<typeof navigator.pushStack>,
 }
@@ -241,14 +241,14 @@ interface PopStackFunction {
    *
    * @param props the parameters for this navigation:
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @return an instance of Action
+   * @returns an instance of Action
    */
    (...args: Parameters<typeof navigator.popStack>): ReturnType<typeof navigator.popStack>,
 
   /**
    * Pops the current stack, going back to the last route of the previous stack.
    *
-   * @return an instance of Action
+   * @returns an instance of Action
    * */
    (): Action,
 }
@@ -260,7 +260,7 @@ interface PopToViewFunction {
    *
    * @param routeId the identifier of the route to go back to. For RemoteViews, this identifier
    * will be the url. For LocalViews, it will the id of the root component.
-   * @return an instance of Action
+   * @returns an instance of Action
    */
    (routeId: Expression<string>): Action,
 
@@ -271,7 +271,7 @@ interface PopToViewFunction {
    * @param props the parameters for this navigation:
    * - route: the identifier for the screen to go back to.
    * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
-   * @return an instance of Action
+   * @returns an instance of Action
    */
   (...args: Parameters<typeof navigator.popToView>): ReturnType<typeof navigator.popToView>,
 }
@@ -281,7 +281,7 @@ interface ResetStackFunction {
    * Removes the current navigation stack and adds a new one with the provided route.
    *
    * @param url the url to the screen to load
-   * @return an instance of Action
+   * @returns an instance of Action
    */
   (url: Expression<string>): Action,
 
@@ -320,7 +320,7 @@ interface ResetApplicationFunction {
    * Removes all the navigation stacks and adds a new one with the provided route.
    *
    * @param url the url to the screen to load
-   * @return an instance of Action
+   * @returns an instance of Action
    */
    (url: Expression<string>): Action,
 

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -239,18 +239,19 @@ interface PopStackFunction {
   /**
    * Pops the current stack, going back to the last route of the previous stack.
    *
-   * @param props the parameters for this navigation:
-   * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
+   *
    */
-   (...args: Parameters<typeof navigator.popStack>): ReturnType<typeof navigator.popStack>,
+  (): Action,
 
   /**
    * Pops the current stack, going back to the last route of the previous stack.
    *
+   * @param props the parameters for this navigation:
+   * - navigationContext: the Context for this navigation. See {@link BaseNavigationParams}.
    * @returns an instance of Action
-   * */
-   (): Action,
+   */
+  (...args: Parameters<typeof navigator.popStack>): ReturnType<typeof navigator.popStack>,
 }
 
 interface PopToViewFunction {
@@ -299,6 +300,13 @@ interface ResetStackFunction {
 
 interface PopViewFunction {
   /**
+  * Goes back to the previous route.
+  *
+  * @returns an instance of Action
+  * */
+  (): Action,
+
+  /**
    * Goes back to the previous route.
    *
    * @param props the parameters for this navigation:
@@ -306,13 +314,6 @@ interface PopViewFunction {
    * @returns an instance of Action
    */
   (...args: Parameters<typeof navigator.popView>): ReturnType<typeof navigator.popView>,
-
-  /**
-   * Goes back to the previous route.
-   *
-   * @returns an instance of Action
-   * */
-  (): Action,
 }
 
 interface ResetApplicationFunction {

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -1,4 +1,3 @@
-import { has } from 'lodash'
 import { Expression, HttpMethod } from '../types'
 import { Action } from '../model/action'
 import { Component } from '../model/component'
@@ -341,7 +340,7 @@ interface ResetApplicationFunction {
 function getParams(props: any, isPopToView?: boolean) {
   const isParamASingleUrl = typeof props === 'string' || isDynamicExpression(props)
   if (isParamASingleUrl) return { route: isPopToView ? props : { url: props } }
-  if (props && has(props, ['route', 'screen']) && !props.route.screen.id) {
+  if (props?.route?.screen && !props.route.screen.id) {
     throw new Error(`
       The screen component must have an id, to perform a local navigation.
       Root component: "${props?.route?.screen?.namespace ?? 'namespace'}:${props?.route?.screen?.name ?? 'name'}".

--- a/core/src/actions/send-request.ts
+++ b/core/src/actions/send-request.ts
@@ -202,7 +202,7 @@ export function request<SuccessResponse = any, ErrorResponse = any>() {
      * Please check {@link request} for more details.
      *
      * @param curryFn function to create the options for the sendRequest action
-     * @return a function to create a sendRequest action
+     * @returns a function to create a sendRequest action
      */
     compose,
   }

--- a/core/src/model/action.ts
+++ b/core/src/model/action.ts
@@ -61,23 +61,6 @@ export interface WithAnalytics<Props = any> {
   analytics?: AnalyticsConfig<Props>,
 }
 
-interface ActionInterface<Props = any> extends WithAnalytics<Props> {
-  /**
-   * The namespace for this action. Actions in beagle are identified by a string in the format "$namespace:$name", e.g
-   * "beagle:alert".
-   */
-  namespace?: string,
-  /**
-   * The name for this action. Actions in beagle are identified by a string in the format "$namespace:$name", e.g
-   * "beagle:alert".
-   */
-  name: string,
-  /**
-   * The properties for this action,
-   */
-  properties?: Props,
-}
-
 /**
  * Utility type to include the properties that should be included in every action.
  *
@@ -134,21 +117,32 @@ export type Actions = Action | Action[]
  * This is a very simple example and it omits many of the properties of an Alert action. To create an action factory
  * with all properties of an Action, check the helper method {@link createAction}.
  */
-export class Action<Props = any> implements ActionInterface<Props> {
+export interface Action<Props = any> extends WithAnalytics<Props> {
+  /**
+   * The namespace for this action. Actions in beagle are identified by a string in the format "$namespace:$name", e.g
+   * "beagle:alert".
+   */
+  namespace?: string,
+  /**
+   * The name for this action. Actions in beagle are identified by a string in the format "$namespace:$name", e.g
+   * "beagle:alert".
+   */
+  name: string,
+  /**
+   * The properties for this action,
+   */
+  properties?: Props,
+}
+export class Action<Props = any> {
   /**
    * @param options the action parameters: namespace, name, properties and analytics. See {@link ActionInterface}.
    */
-  constructor({ name, analytics, namespace, properties }: ActionInterface<Props>) {
+  constructor({ name, analytics, namespace, properties }: Action<Props>) {
     this.name = name
     this.namespace = namespace
     this.analytics = analytics
     this.properties = properties
   }
-
-  namespace?
-  name
-  properties?
-  analytics?
 }
 
 /**

--- a/core/src/model/component.ts
+++ b/core/src/model/component.ts
@@ -55,7 +55,6 @@ export interface Component extends WithContext, WithChildren {
   /**
    * An optional id for this component.
    * This is important for debugging or for identifying it in structures like the Action addChildren.
-   * ATTENTION: this id property is REQUIRED to perform local navigations.
   */
   id?: string,
   /**

--- a/core/src/model/component.ts
+++ b/core/src/model/component.ts
@@ -17,28 +17,6 @@ export interface WithChildren {
   children?: Component | Component[] | null,
 }
 
-interface ComponentInterface extends WithContext, WithChildren {
-  /**
-   * An id for this component. This is important for debugging or for identifying it in structures like the Action
-   * addChildren.
-   */
-  id?: string,
-  /**
-   * All the properties for this Component.
-   */
-  properties?: Record<string, any>,
-  /**
-   * The name of the Component. Every Component type is identified in the front-end by a string in the format
-   * "$namespace:$name". The Container, for instance is a "beagle:container".
-   */
-  name: string,
-  /**
-   * The namespace of the Component. Every Component type is identified in the front-end by a string in the format
-   * "$namespace:$name". The Container, for instance is a "beagle:container".
-   */
-  namespace?: string,
-}
-
 /**
  * The Component is Beagle's main structure. It is a node in the UI tree the backend returns to the frontend.
  *
@@ -72,12 +50,35 @@ interface ComponentInterface extends WithContext, WithChildren {
  *
  * To know more about the properties of `<component />`, check {@link ComponentInterface}.
  */
-export class Component implements ComponentInterface {
+
+export interface Component extends WithContext, WithChildren {
+  /**
+   * An optional id for this component.
+   * This is important for debugging or for identifying it in structures like the Action addChildren.
+   * ATTENTION: this id property is REQUIRED to perform local navigations.
+  */
+  id?: string,
+  /**
+   * All the properties for this Component.
+   */
+  properties?: Record<string, any>,
+  /**
+   * The name of the Component. Every Component type is identified in the front-end by a string in the format
+   * "$namespace:$name". The Container, for instance is a "beagle:container".
+   */
+  name: string,
+  /**
+   * The namespace of the Component. Every Component type is identified in the front-end by a string in the format
+   * "$namespace:$name". The Container, for instance is a "beagle:container".
+   */
+  namespace?: string,
+}
+export class Component {
   /**
    * @param options the component parameters: properties, children, context, id, name and namespace. See
    * {@link ComponentInterface}.
    */
-  constructor({ properties, children, context, id, name, namespace }: ComponentInterface) {
+  constructor({ properties, children, context, id, name, namespace }: Component) {
     this.id = id
     this.children = children
     this.context = context
@@ -85,11 +86,4 @@ export class Component implements ComponentInterface {
     this.name = name
     this.namespace = namespace
   }
-
-  namespace?
-  id?
-  name
-  children?
-  context?
-  properties?
 }

--- a/sample/src/beagle/screens/other/test.tsx
+++ b/sample/src/beagle/screens/other/test.tsx
@@ -2,6 +2,4 @@ import { BeagleJSX } from '@zup-it/beagle-backend-core'
 import { Text } from '@zup-it/beagle-backend-components'
 import { Screen } from '@zup-it/beagle-backend-express'
 
-export const Test: Screen = () => (
-  <Text>Hello World!</Text>
-)
+export const Test: Screen = () => <Text>Hello World!</Text>

--- a/sample/src/beagle/screens/other/welcome.tsx
+++ b/sample/src/beagle/screens/other/welcome.tsx
@@ -18,10 +18,5 @@ export const Welcome: Screen = () => (
     <Text style={{ marginTop: 40 }}>Welcome to the Beagle Playground!</Text>
     <Text style={{ marginTop: 5 }}>Use the panel on the left to start coding!</Text>
     <Button style={{ marginTop: 40 }} onPress={pushView('/docs.json')}>Access the fast guide</Button>
-    <Button onPress={pushView({
-      route: {
-        screen: <Text id="arthur">Hello World!</Text>
-      }
-    })}>Test</Button>
   </Container>
 )

--- a/sample/src/beagle/screens/other/welcome.tsx
+++ b/sample/src/beagle/screens/other/welcome.tsx
@@ -2,6 +2,7 @@ import { BeagleJSX } from '@zup-it/beagle-backend-core'
 import { Screen } from '@zup-it/beagle-backend-express'
 import { pushView } from '@zup-it/beagle-backend-core/actions'
 import { Button, colors, Container, Image, Text } from '@zup-it/beagle-backend-components'
+import { Test } from './test'
 
 export const Welcome: Screen = () => (
   <Container
@@ -17,5 +18,10 @@ export const Welcome: Screen = () => (
     <Text style={{ marginTop: 40 }}>Welcome to the Beagle Playground!</Text>
     <Text style={{ marginTop: 5 }}>Use the panel on the left to start coding!</Text>
     <Button style={{ marginTop: 40 }} onPress={pushView('/docs.json')}>Access the fast guide</Button>
+    <Button onPress={pushView({
+      route: {
+        screen: <Text id="arthur">Hello World!</Text>
+      }
+    })}>Test</Button>
   </Container>
 )


### PR DESCRIPTION
Signed-off-by: Arthur Bleil <arthur.bleil@zup.com.br>

Story: [235218 - Certificar-se de que navegações locais tenham ids na raiz](https://app.shortcut.com/stackspot/story/235218/certificar-se-de-que-navega%C3%A7%C3%B5es-locais-tenham-ids-na-raiz)

Solution adopted: Validation on runtime.

SIDE NOTE: I did an extensive research about validation of the JSX elements attributes through TypeScript's new features, and at the conclusion of it I noticed that TypeScript do not support multiple signatures of interfaces and classes (on previous versions was possible to extend conditionally, but it changed since 3.8).