### PR TITLE
tests: tests for the express module

### DIFF
--- a/express-client/__tests__/beagle-app.spec.ts
+++ b/express-client/__tests__/beagle-app.spec.ts
@@ -1,0 +1,121 @@
+import { Component, createContextNode, serialize } from '@zup-it/beagle-backend-core'
+import { Express, RequestParamHandler, Request, Response } from 'express'
+import { BeagleApp, RouteMap } from 'src'
+
+// mocks the navigator
+jest.mock('src/navigator', () => ({
+  __esModule: true,
+  Navigator: class {
+    constructor(routes: RouteMap) {
+      this.routes = routes
+    }
+
+    routes: RouteMap
+  },
+}))
+
+const createMockedExpress = () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+  patch: jest.fn(),
+} as unknown as Express)
+
+const createMockedRequest = () => ({ url: 'test' } as unknown as Request)
+
+const createMockedResponse = () => ({
+  type: jest.fn(),
+  setHeader: jest.fn(),
+  send: jest.fn(),
+} as unknown as Response)
+
+describe('Beagle App', () => {
+  const component = new Component({ name: 'test' })
+  const testScreen = jest.fn(() => component)
+
+  it('should add functional routes', () => {
+    const express = createMockedExpress()
+    new BeagleApp(express, {
+      'route1': testScreen,
+      'route2': testScreen,
+    })
+    expect(express.get).toHaveBeenCalledTimes(2)
+    expect(express.get).toHaveBeenNthCalledWith(1, 'route1', expect.any(Function))
+    expect(express.get).toHaveBeenNthCalledWith(2, 'route2', expect.any(Function))
+  })
+
+  it('should add mapped routes', () => {
+    const express = createMockedExpress()
+    new BeagleApp(express, {
+      'defaultRoute': { screen: testScreen },
+      'getRoute': { method: 'get', screen: testScreen },
+      'putRoute': { method: 'put', screen: testScreen },
+      'postRoute': { method: 'post', screen: testScreen },
+      'deleteRoute': { method: 'delete', screen: testScreen },
+      'patchRoute': { method: 'patch', screen: testScreen },
+    })
+    expect(express.get).toHaveBeenCalledTimes(2)
+    expect(express.get).toHaveBeenNthCalledWith(1, 'defaultRoute', expect.any(Function))
+    expect(express.get).toHaveBeenNthCalledWith(2, 'getRoute', expect.any(Function))
+    expect(express.put).toHaveBeenCalledTimes(1)
+    expect(express.put).toHaveBeenNthCalledWith(1, 'putRoute', expect.any(Function))
+    expect(express.post).toHaveBeenCalledTimes(1)
+    expect(express.post).toHaveBeenNthCalledWith(1, 'postRoute', expect.any(Function))
+    expect(express.delete).toHaveBeenCalledTimes(1)
+    expect(express.delete).toHaveBeenNthCalledWith(1, 'deleteRoute', expect.any(Function))
+    expect(express.patch).toHaveBeenCalledTimes(1)
+    expect(express.patch).toHaveBeenNthCalledWith(1, 'patchRoute', expect.any(Function))
+  })
+
+  it('should use basePath to setup routes', () => {
+    const express = createMockedExpress()
+    new BeagleApp(
+      express,
+      {
+        'route1': testScreen,
+        'route2': { method: 'put', screen: testScreen },
+      },
+      { basePath: 'beagle/' },
+    )
+    expect(express.get).toHaveBeenCalledWith('beagle/route1', expect.any(Function))
+    expect(express.put).toHaveBeenCalledWith('beagle/route2', expect.any(Function))
+  })
+
+  describe('When a request is made to a screen', () => {
+    const express = createMockedExpress()
+    const request = createMockedRequest()
+    const response = createMockedResponse()
+    const routes: RouteMap = { 'route': testScreen }
+    new BeagleApp(express, routes, { responseHeaders: { platform: 'test', hello: 'world' } })
+    const handler: RequestParamHandler = (express.get as jest.Mock).mock.calls[0][1]
+    handler(request, response, jest.fn(), null, '')
+
+    it('should add response headers', () => {
+      expect(response.setHeader).toHaveBeenCalledTimes(2)
+      expect(response.setHeader).toHaveBeenNthCalledWith(1, 'platform', 'test')
+      expect(response.setHeader).toHaveBeenNthCalledWith(2, 'hello', 'world')
+    })
+
+    it('should set type', () => {
+      expect(response.type).toHaveBeenCalledTimes(1)
+      expect(response.type).toHaveBeenCalledWith('application/json')
+    })
+
+    it('should call the screen function with the request, response, navigationContext and navigator', () => {
+      expect(testScreen).toHaveBeenCalledTimes(1)
+      expect(testScreen).toHaveBeenCalledWith({
+        request,
+        response,
+        navigationContext: createContextNode('navigationContext'),
+        navigator: { routes },
+      })
+    })
+
+    it('should serialize the resulting component and set it as the response body', () => {
+      const serialized = serialize(component)
+      expect(response.send).toHaveBeenCalledTimes(1)
+      expect(response.send).toHaveBeenCalledWith(serialized)
+    })
+  })
+})

--- a/express-client/__tests__/navigator.spec.ts
+++ b/express-client/__tests__/navigator.spec.ts
@@ -1,0 +1,174 @@
+import { Component } from '@zup-it/beagle-backend-core'
+import {
+  popStack, popToView, popView, pushStack, pushView, PushViewParams, resetApplication, resetStack,
+} from '@zup-it/beagle-backend-core/actions'
+import { AnalyticsConfig } from '@zup-it/beagle-backend-core/model/action'
+import { omit } from 'lodash'
+import { Navigator } from 'src/navigator'
+import { RouteMap } from 'src/route'
+import { Screen } from 'src'
+
+describe('Navigator', () => {
+  const component = new Component({ name: 'test' })
+  const screenA = () => component
+  const screenB = () => component
+  const screenC = () => component
+  const screenD = () => component
+  const routes: RouteMap = {
+    'my-screen-a': screenA,
+    'my-screen-b': { screen: screenB },
+    'my-screen-c': { method: 'post', screen: screenC },
+    'my-screen-d/:id/:resource': screenD,
+  }
+  const navigator = new Navigator(routes)
+
+  describe('Push and reset navigations', () => {
+    function testNavigation(navigatorFn: any, actionFactory: any, options?: any) {
+      const actionA = navigatorFn(screenA, options)
+      const actionB = navigatorFn(screenB, options)
+      const actionC = navigatorFn(screenC, options)
+      expect(actionA).toEqual(actionFactory({ route: { url: 'my-screen-a' } }))
+      expect(actionB).toEqual(actionFactory({ route: { url: 'my-screen-b' } }))
+      expect(actionC).toEqual(actionFactory({
+        route: {
+          url: 'my-screen-c',
+          httpAdditionalData: { method: 'post' },
+        },
+      }))
+    }
+
+    it('should create actions to pushView', () => {
+      testNavigation(navigator.pushView, pushView)
+    })
+
+    it('should create actions to pushStack', () => {
+      testNavigation(navigator.pushStack, pushStack)
+    })
+
+    it('should create actions to resetStack', () => {
+      testNavigation(navigator.resetStack, resetStack)
+    })
+
+    it('should create actions to resetApplication', () => {
+      testNavigation(navigator.resetApplication, resetApplication)
+    })
+
+    it('should throw error when navigating to unregistered screen', () => {
+      expect(() => navigator.pushView(() => component)).toThrow()
+    })
+  })
+
+  describe('Pop navigations', () => {
+    it('should create action to popView', () => {
+      const action = navigator.popView()
+      expect(action).toEqual(popView())
+    })
+
+    it('should create action to popToView', () => {
+      const actionA = navigator.popToView(screenA)
+      const actionC = navigator.popToView(screenC)
+      expect(actionA).toEqual(popToView({ route: 'my-screen-a' }))
+      expect(actionC).toEqual(popToView({ route: 'my-screen-c' }))
+    })
+
+    it('should create action to popStack', () => {
+      const action = navigator.popStack()
+      expect(action).toEqual(popStack())
+    })
+  })
+
+  describe('Options', () => {
+    function testActionWithOptions(screen: Screen, navigationFn: any, options: any, expected: any) {
+      const action = (navigationFn === navigator.popView || navigationFn === navigator.popStack)
+        ? navigationFn(options)
+        : navigationFn(screen, options)
+      expect(action).toEqual(expected)
+    }
+
+    function testAllPushResetActions(
+      options: any,
+      expectedParams: any,
+      { exclude = [], screen = screenA }: { exclude?: string[], screen?: Screen } = {}) {
+      if (!exclude.includes('pushView')) {
+        testActionWithOptions(screen, navigator.pushView, options, pushView(expectedParams))
+      }
+      if (!exclude.includes('pushStack')) {
+        testActionWithOptions(screen, navigator.pushStack, options, pushStack(expectedParams))
+      }
+      if (!exclude.includes('resetStack')) {
+        testActionWithOptions(screen, navigator.resetStack, options, resetStack(expectedParams))
+      }
+      if (!exclude.includes('resetApplication')) {
+        testActionWithOptions(screen, navigator.resetApplication, options, resetApplication(expectedParams))
+      }
+    }
+
+    function testAllPopActions(options: any, expectedParams: any, screen: Screen = screenA) {
+      testActionWithOptions(screen, navigator.popView, options, popView(omit(expectedParams, 'route')))
+      testActionWithOptions(screen, navigator.popStack, options, popStack(omit(expectedParams, 'route')))
+      testActionWithOptions(screen, navigator.popToView, options, popToView(expectedParams))
+    }
+
+    it('should create action with analytics', () => {
+      const analytics: AnalyticsConfig<PushViewParams> = { additionalEntries: { test: 1 }, attributes: { route: true } }
+      testAllPushResetActions({ analytics }, { route: { url: expect.any(String) }, analytics })
+      testAllPopActions({ analytics }, { route: expect.any(String), analytics })
+    })
+
+    it('should create action with request body', () => {
+      const body = { a: 1, b: 2, c: '3' }
+      testAllPushResetActions(
+        { body },
+        { route: { url: expect.any(String), httpAdditionalData: { body, method: 'post' } } },
+        { screen: screenC },
+      )
+    })
+
+    it('should create action with controllerId', () => {
+      const controllerId = 'test'
+      testAllPushResetActions(
+        { controllerId },
+        { route: { url: expect.any(String) }, controllerId },
+        { exclude: ['pushView'] },
+      )
+    })
+
+    it('should create action with fallback', () => {
+      const fallback = new Component({ name: 'fallback' })
+      testAllPushResetActions({ fallback }, { route: { url: expect.any(String), fallback } })
+    })
+
+    it('should create action with headers', () => {
+      const headers = { 'my-header': 'my-value' }
+      testAllPushResetActions({ headers }, { route: { url: expect.any(String), httpAdditionalData: { headers } } })
+    })
+
+    it('should create action with navigationContext', () => {
+      const navigationContext = { address: { zip: '00000000' } }
+      testAllPushResetActions({ navigationContext }, { route: { url: expect.any(String) }, navigationContext })
+      testAllPopActions({ navigationContext }, { route: expect.any(String), navigationContext })
+    })
+
+    it('should create action with query params', () => {
+      const query = { a: 'hello world', b: '&?' }
+      testAllPushResetActions(
+        { query },
+        { route: { url: expect.stringMatching(/\?((a=hello%20world&b=%26%3F)|(b=%26%3F&a=hello%20world))$/) },
+      })
+    })
+
+    it('should create action with route params', () => {
+      const routeParams = { id: 'a & b', resource: 'test' }
+      testAllPushResetActions(
+        { routeParams },
+        { route: { url: 'my-screen-d/a%20%26%20b/test' } },
+        { screen: screenD },
+      )
+    })
+
+    it('should create action with shouldPrefetch', () => {
+      const shouldPrefetch = true
+      testAllPushResetActions({ shouldPrefetch }, { route: { url: expect.any(String), shouldPrefetch } })
+    })
+  })
+})

--- a/express-client/__tests__/utils.spec.ts
+++ b/express-client/__tests__/utils.spec.ts
@@ -1,0 +1,27 @@
+import { isWeb, isMobile } from 'src/utils/headers'
+import { BeagleHeaders } from 'src/utils/types'
+
+describe('Utils: headers', () => {
+  const webHeaders: BeagleHeaders = { 'beagle-platform': 'WEB' }
+  const mobileHeaders: BeagleHeaders = { 'beagle-platform': 'MOBILE' }
+
+  it('should be a web platform', () => {
+    expect(isWeb(webHeaders)).toBe(true)
+  })
+
+  it('should not be a web platform', () => {
+    expect(isWeb({})).toBe(false)
+    expect(isWeb(mobileHeaders)).toBe(false)
+  })
+
+  it('should be a mobile platform', () => {
+    expect(isMobile(mobileHeaders)).toBe(true)
+  })
+
+  it('should not be a mobile platform', () => {
+    expect(isMobile({})).toBe(false)
+    expect(isMobile(webHeaders)).toBe(false)
+  })
+})
+
+

--- a/express-client/jest.config.js
+++ b/express-client/jest.config.js
@@ -7,13 +7,15 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^@zup-it/beagle-backend-core$': '<rootDir>../core/src',
+    '^@zup-it/beagle-backend-core/(.*)$': '<rootDir>../core/src/$1',
+    '^src$': '<rootDir>/src',
     '^src/(.*)$': '<rootDir>/src/$1',
     '^test/(.*)$': '<rootDir>/__tests__/$1',
   },
   setupFilesAfterEnv: ['jest-extended'],
   globals: {
     'ts-jest': {
-      tsconfig: '__tests__/tsconfig.json',
+      tsconfig: '<rootDir>/__tests__/tsconfig.json',
     },
   },
 }

--- a/express-client/src/beagle-app.ts
+++ b/express-client/src/beagle-app.ts
@@ -56,7 +56,7 @@ export class BeagleApp {
     const { method = 'get', path } = properties
     this.express[method](`${this.basePath}${path}`, (req, res) => {
       res.type('application/json')
-      forEach(this.responseHeaders, (key, value) => res.setHeader(key, value))
+      forEach(this.responseHeaders, (value, key) => res.setHeader(key, value))
       const componentTree = screen({
         request: req as RequestWithCustomHeaders,
         response: res,
@@ -70,7 +70,7 @@ export class BeagleApp {
   private addRouteMap(routeMap: RouteMap) {
     forEach(routeMap, (value, key) => {
       if (typeof value === 'function') this.addRoute(value, { path: key })
-      else this.addRoute(value.screen, { path: key })
+      else this.addRoute(value.screen, { path: key, method: value.method })
     })
   }
 }

--- a/express-client/src/navigator.ts
+++ b/express-client/src/navigator.ts
@@ -2,7 +2,7 @@ import { FC } from '@zup-it/beagle-backend-core'
 import {
   pushView, pushStack, popToView, popView, popStack, resetApplication, resetStack, Route,
 } from '@zup-it/beagle-backend-core/actions'
-import { forEach } from 'lodash'
+import { forEach, isEmpty, map } from 'lodash'
 import {
   ControllerId, PopStackAction, PopToViewAction, PopViewAction, PushStackAction,
   PushViewAction, ResetApplicationAction, ResetStackAction,
@@ -35,7 +35,7 @@ export class Navigator {
    * @param routeMap the same routeMap received by BeagleApplication.
    * @param basePath the same basePath received by BeagleApplication options.
    */
-  constructor(routeMap: RouteMap, private basePath = '') {
+  constructor(routeMap: RouteMap) {
     this.screenMap = new Map()
     forEach(routeMap, (value, key) => this.screenMap.set(
       typeof value === 'function' ? value : value.screen,
@@ -47,21 +47,28 @@ export class Navigator {
 
   private getPathAndMethod(screen: FC<any>) {
     if (!this.screenMap.has(screen)) {
-      throw new Error(`Couldn't find any route corresponding to "${screen}". Are you sure you registered it via BeagleApp.addScreen?`)
+      throw new Error(
+        "Couldn't find any route corresponding to the provided screen. Are you sure you registered it in the route map provided to the BeagleApp?",
+      )
     }
     return this.screenMap.get(screen)!
   }
 
-  private buildUrl(path: string, routeParams: Record<string, string> = {}) {
-    return path.replace(/:(\w+)/g, (_, name) => name in routeParams ? routeParams[name] : `:${name}`)
+  private buildUrl(path: string, routeParams: Record<string, string> = {}, query?: Record<string, string>) {
+    const withRouteParams = path.replace(
+      /:(\w+)/g,
+      (_, name) => name in routeParams ? encodeURIComponent(routeParams[name]) : `:${name}`,
+    )
+    const queryParts = map(query, (value, key) => `${key}=${encodeURIComponent(value)}`)
+    return isEmpty(queryParts) ? withRouteParams : `${withRouteParams}?${queryParts.join('&')}`
   }
 
   private buildRoute({ type, screen, properties = {} }: GenericRemoteNavigation) {
     if (type === 'popView' || type === 'popStack') return undefined
 
-    const { routeParams, headers, body, shouldPrefetch, fallback } = properties
+    const { routeParams, headers, body, shouldPrefetch, fallback, query } = properties
     const { path, method } = this.getPathAndMethod(screen!)
-    const url = this.buildUrl(`${this.basePath}${path}`, routeParams ?? {})
+    const url = this.buildUrl(path, routeParams, query)
     if (type === 'popToView') return url
 
     const httpAdditionalData = method || headers || body ? { method, headers, body } : undefined


### PR DESCRIPTION
- Create tests
- Removes the baseUrl from the navigator
- Fixes problem where the query parameters wouldn't be passed in a navigation
- Fixes problem where the route parameters wouldn't be encoded
- Fixes problem where headers would be created as `value: key` instead of `key: value`
- Fixes problem where the navigator would ignore the request method
- When the screen was not found by the navigator, the entire screen function would get logged. This has been changed to only log "the provided screen".