### PR TITLE
tests: tests for conditional rendering [review after #20 is accepted]

### DIFF
--- a/components/__tests__/fragments/conditional-render.spec.tsx
+++ b/components/__tests__/fragments/conditional-render.spec.tsx
@@ -1,0 +1,111 @@
+import { BeagleJSX, coreNamespace, createContextNode, serialize } from '@zup-it/beagle-backend-core'
+import { condition } from '@zup-it/beagle-backend-core/operations'
+import { If, Then, Else } from 'src/fragments/conditional-render'
+import { Style } from 'src/style/simple-styles'
+
+describe('Conditional render', () => {
+  const shouldRender = createContextNode<boolean>('ctx')
+
+  it('should render If', () => {
+    const component = (
+      <If condition={shouldRender}>
+        <Then>
+          <component name="test" />
+        </Then>
+      </If>
+    )
+    expect(component).toEqual(
+      <component name="test" properties={{ style: { display: condition(shouldRender, 'FLEX', 'NONE') } }} />
+    )
+  })
+
+  it('should render If-Else', () => {
+    const component = (
+      <If condition={shouldRender}>
+        <Then>
+          <component name="test-then" />
+        </Then>
+        <Else>
+          <component name="test-else" />
+        </Else>
+      </If>
+    )
+    expect(component).toEqual(
+      <component name="container" namespace={coreNamespace} properties={{}}>
+        <component name="test-then" properties={{ style: { display: condition(shouldRender, 'FLEX', 'NONE') } }} />
+        <component name="test-else" properties={{ style: { display: condition(shouldRender, 'NONE', 'FLEX') } }} />
+      </component>
+    )
+  })
+
+  it("should throw if If doesn't have a Then as a child", () => {
+    const createComponent = () => (
+      <If condition={shouldRender}>
+        <Else>
+          <component name="test-else" />
+        </Else>
+      </If>
+    )
+    expect(createComponent).toThrow()
+  })
+
+  it('should throw if If have children other than Then or Else', () => {
+    const createComponent = () => (
+      <If condition={shouldRender}>
+        <Then>
+          <component name="test-then" />
+        </Then>
+        <component name="test" />
+      </If>
+    )
+    expect(createComponent).toThrow()
+  })
+
+  it('When serializing in development mode: should throw if Then is child of something other than If', () => {
+    const env = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    const component = (
+      <component name="test">
+        <Then>
+          <component name="test-then" />
+        </Then>
+      </component>
+    )
+    expect(() => serialize(component)).toThrow()
+    process.env.NODE_ENV = env
+  })
+
+  it('When serializing in development mode: should throw if Else is child of something other than If', () => {
+    const env = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    const component = (
+      <component name="test">
+        <Else>
+          <component name="test-then" />
+        </Else>
+      </component>
+    )
+    expect(() => serialize(component)).toThrow()
+    process.env.NODE_ENV = env
+  })
+
+  it('should transfer id and styles', () => {
+    const style: Style = { backgroundColor: '#FFF' }
+    const component = (
+      <If condition={shouldRender} id="test" style={style}>
+        <Then>
+          <component name="test-then" />
+        </Then>
+        <Else>
+          <component name="test-else" />
+        </Else>
+      </If>
+    )
+    expect(component).toEqual(
+      <component name="container" namespace={coreNamespace} id="test" properties={{ style }}>
+        <component name="test-then" properties={{ style: { display: condition(shouldRender, 'FLEX', 'NONE') } }} />
+        <component name="test-else" properties={{ style: { display: condition(shouldRender, 'NONE', 'FLEX') } }} />
+      </component>
+    )
+  })
+})

--- a/components/__tests__/style.spec.tsx
+++ b/components/__tests__/style.spec.tsx
@@ -1,0 +1,332 @@
+import { BeagleJSX, coreNamespace, createContext, createContextNode } from '@zup-it/beagle-backend-core'
+import { sum } from '@zup-it/beagle-backend-core/operations'
+import { omit } from 'lodash'
+import { UnitValue } from 'src/style/full-styles'
+import { CornerRadius, EachCornerRadius, Margin, Padding, Position, Size, Style } from 'src/style/simple-styles'
+import { StyledComponent, StyledDefaultComponent } from 'src/style/styled'
+import { validateColor } from 'src/validations'
+
+jest.mock('src/validations', () => ({
+    __esModule: true,
+    validateColor: jest.fn(),
+}))
+
+describe('Style', () => {
+  describe('StyleValue (UnitValue)', () => {
+    it('should create a UnitValue (real) from number', () => {
+      const component = <StyledComponent name='test' style={{ flexBasis: 1.2 }} />
+      expect(component.properties?.style).toEqual({
+        flex: {
+          basis: { type: 'REAL', value: 1.2 },
+        },
+      })
+    })
+
+    it('should create a UnitValue (real) from an expression', () => {
+      const context = createContextNode<number>('ctx')
+      const basis = sum(context, 1)
+      const component = <StyledComponent name='test' style={{ flexBasis: basis }} />
+      expect(component.properties?.style).toEqual({
+        flex: {
+          basis: { type: 'REAL', value: basis },
+        },
+      })
+    })
+
+    it('should create a UnitValue (percent) from a string', () => {
+      const component = <StyledComponent name='test' style={{ flexBasis: '15%' }} />
+      expect(component.properties?.style).toEqual({
+        flex: {
+          basis: { type: 'PERCENT', value: 15 },
+        },
+      })
+    })
+
+    it('should return the UnitValue if it was already a UnitValue', () => {
+      const basis: UnitValue = { type: 'PERCENT', value: 20 }
+      const component = <StyledComponent name='test' style={{ flexBasis: basis }} />
+      expect(component.properties?.style).toEqual({ flex: { basis } })
+    })
+  })
+
+  describe('Flex', () => {
+    it('should create style with every flex property', () => {
+      const style: Style = {
+        alignContent: 'CENTER',
+        alignItems: 'BASELINE',
+        alignSelf: 'AUTO',
+        flex: 1,
+        flexBasis: 2,
+        flexDirection: 'COLUMN',
+        flexGrow: 3,
+        flexShrink: 4,
+        flexWrap: 'NO_WRAP',
+        justifyContent: 'CENTER',
+      }
+      const component = <StyledComponent name='test' style={style} />
+      expect(component.properties?.style).toEqual({
+        flex: {
+          ...omit(style, ['flexBasis', 'flexGrow', 'flexShrink']),
+          basis: { type: 'REAL', value: 2 },
+          grow: 3,
+          shrink: 4,
+        },
+      })
+    })
+  })
+
+  describe('Corner radius', () => {
+    it('should create style with the same value for all corners', () => {
+      const component = <StyledComponent name='test' style={{ cornerRadius: 10 }} />
+      expect(component.properties?.style).toEqual({ cornerRadius: { radius: 10 } })
+    })
+
+    it('should create style with the same value for all corners (expression)', () => {
+      const ctx = createContextNode<number>('ctx')
+      const component = <StyledComponent name='test' style={{ cornerRadius: ctx }} />
+      expect(component.properties?.style).toEqual({ cornerRadius: { radius: ctx } })
+    })
+
+    it('should create style with the one value for each corner', () => {
+      const cornerRadius: CornerRadius = {
+        bottomLeft: 1,
+        bottomRight: 2,
+        topLeft: 3,
+        topRight: 4,
+      }
+      const component = <StyledComponent name='test' style={{ cornerRadius }} />
+      expect(component.properties?.style).toEqual({ cornerRadius })
+    })
+
+    it('should create style with the one value for each corner (expression)', () => {
+      const ctx = createContextNode<{ [k in keyof EachCornerRadius]: number }>('ctx')
+      const cornerRadius: CornerRadius = {
+        bottomLeft: ctx.get('bottomLeft'),
+        bottomRight: ctx.get('bottomRight'),
+        topLeft: ctx.get('topLeft'),
+        topRight: ctx.get('topRight'),
+      }
+      const component = <StyledComponent name='test' style={{ cornerRadius }} />
+      expect(component.properties?.style).toEqual({ cornerRadius })
+    })
+  })
+
+  describe('Position', () => {
+    it('should create style with positions', () => {
+      const position: Position = {
+        top: 10,
+        left: 11,
+        right: 12,
+        bottom: 13,
+      }
+      const component = <StyledComponent name='test' style={{ ...position }} />
+      expect(component.properties?.style).toEqual({
+        position: {
+          top: { type: 'REAL', value: 10 },
+          left: { type: 'REAL', value: 11 },
+          right: { type: 'REAL', value: 12 },
+          bottom:{ type: 'REAL', value: 13 },
+        },
+      })
+    })
+  })
+
+  describe('Padding', () => {
+    it('should create style with one padding value for all sides', () => {
+      const component = <StyledComponent name='test' style={{ padding: 10 }} />
+      expect(component.properties?.style).toEqual({
+        padding: { all: { type: 'REAL', value: 10 } },
+      })
+    })
+
+    it('should create style with padding values for each side', () => {
+      const padding: Padding = {
+        paddingBottom: 1,
+        paddingEnd: 2,
+        paddingHorizontal: 3,
+        paddingLeft: 4,
+        paddingRight: 5,
+        paddingStart: 6,
+        paddingTop: 7,
+        paddingVertical: 8,
+      }
+      const component = <StyledComponent name='test' style={{ ...padding }} />
+      expect(component.properties?.style).toEqual({
+        padding: {
+          bottom: { type: 'REAL', value: 1 },
+          end: { type: 'REAL', value: 2 },
+          horizontal: { type: 'REAL', value: 3 },
+          left: { type: 'REAL', value: 4 },
+          right: { type: 'REAL', value: 5 },
+          start: { type: 'REAL', value: 6 },
+          top: { type: 'REAL', value: 7 },
+          vertical: { type: 'REAL', value: 8 },
+        },
+      })
+    })
+  })
+
+  describe('Margin', () => {
+    it('should create style with one margin value for all sides', () => {
+      const component = <StyledComponent name='test' style={{ margin: 10 }} />
+      expect(component.properties?.style).toEqual({
+        margin: { all: { type: 'REAL', value: 10 } },
+      })
+    })
+
+    it('should create style with margin values for each side', () => {
+      const margin: Margin = {
+        marginBottom: 1,
+        marginEnd: 2,
+        marginHorizontal: 3,
+        marginLeft: 4,
+        marginRight: 5,
+        marginStart: 6,
+        marginTop: 7,
+        marginVertical: 8,
+      }
+      const component = <StyledComponent name='test' style={{ ...margin }} />
+      expect(component.properties?.style).toEqual({
+        margin: {
+          bottom: { type: 'REAL', value: 1 },
+          end: { type: 'REAL', value: 2 },
+          horizontal: { type: 'REAL', value: 3 },
+          left: { type: 'REAL', value: 4 },
+          right: { type: 'REAL', value: 5 },
+          start: { type: 'REAL', value: 6 },
+          top: { type: 'REAL', value: 7 },
+          vertical: { type: 'REAL', value: 8 },
+        },
+      })
+    })
+  })
+
+  describe('Size', () => {
+    it('should create style with size', () => {
+      const size: Size = {
+        aspectRatio: 1,
+        height: 2,
+        maxHeight: 3,
+        maxWidth: 4,
+        minHeight: 5,
+        minWidth: 6,
+        width: 7,
+      }
+      const component = <StyledComponent name='test' style={{ ...size }} />
+      expect(component.properties?.style).toEqual({
+        size: {
+          aspectRatio: 1,
+          height: { type: 'REAL', value: 2 },
+          maxHeight: { type: 'REAL', value: 3 },
+          maxWidth: { type: 'REAL', value: 4 },
+          minHeight: { type: 'REAL', value: 5 },
+          minWidth: { type: 'REAL', value: 6 },
+          width: { type: 'REAL', value: 7 },
+        },
+      })
+    })
+  })
+
+  describe('Background', () => {
+    it('should create style with background-color', () => {
+      const component = <StyledComponent name='test' style={{ backgroundColor: '#000' }} />
+      expect(component.properties?.style).toEqual({ backgroundColor: '#000' })
+    })
+
+    it('should create style with background-color (expression)', () => {
+      const ctx = createContextNode<string>('ctx')
+      const component = <StyledComponent name='test' style={{ backgroundColor: ctx }} />
+      expect(component.properties?.style).toEqual({ backgroundColor: ctx })
+    })
+
+    it('should validate background-color', () => {
+      (validateColor as jest.Mock).mockClear()
+      (<StyledComponent name='test' style={{ backgroundColor: '#000' }} />)
+      expect(validateColor).toHaveBeenCalledWith('#000')
+    })
+  })
+
+  describe('Border', () => {
+    it('should create style with border-color', () => {
+      const component = <StyledComponent name='test' style={{ borderColor: '#000' }} />
+      expect(component.properties?.style).toEqual({ borderColor: '#000' })
+    })
+
+    it('should create style with border-color (expression)', () => {
+      const ctx = createContextNode<string>('ctx')
+      const component = <StyledComponent name='test' style={{ borderColor: ctx }} />
+      expect(component.properties?.style).toEqual({ borderColor: ctx })
+    })
+
+    it('should validate border-color', () => {
+      (validateColor as jest.Mock).mockClear()
+      (<StyledComponent name='test' style={{ borderColor: '#000' }} />)
+      expect(validateColor).toHaveBeenCalledWith('#000')
+    })
+
+    it('should create style with border-width', () => {
+      const component = <StyledComponent name='test' style={{ borderWidth: 5 }} />
+      expect(component.properties?.style).toEqual({ borderWidth: 5 })
+    })
+
+    it('should create style with border-width (expression)', () => {
+      const ctx = createContextNode<number>('ctx')
+      const component = <StyledComponent name='test' style={{ borderWidth: ctx }} />
+      expect(component.properties?.style).toEqual({ borderWidth: ctx })
+    })
+  })
+
+  describe('Display', () => {
+    it('should create style with display', () => {
+      const component = <StyledComponent name='test' style={{ display: 'NONE' }} />
+      expect(component.properties?.style).toEqual({ display: 'NONE' })
+    })
+
+    it('should create style with display (expression)', () => {
+      const ctx = createContextNode<'FLEX' | 'NONE'>('ctx')
+      const component = <StyledComponent name='test' style={{ display: ctx }} />
+      expect(component.properties?.style).toEqual({ display: ctx })
+    })
+  })
+
+  describe('Other', () => {
+    it('should have empty style', () => {
+      const component = <StyledComponent name='test' style={{}} />
+      expect(component.properties?.style).toEqual({})
+    })
+
+    it('should create StyledComponent', () => {
+      const ctx = createContext('ctx', 'test')
+      const props = { a: 1, b: '2' }
+      const child = <component name="child" />
+      const style: Style = { display: 'FLEX' }
+      const component = (
+        <StyledComponent name="test" namespace="namespace" context={ctx} id="id" properties={props} style={style}>
+          {child}
+        </StyledComponent>
+      )
+      expect(component).toEqual((
+        <component name="test" namespace="namespace" context={ctx} id="id" properties={{ ...props, style }}>
+          {child}
+        </component>
+      ))
+    })
+
+    it('should create DefaultStyledComponent', () => {
+      const ctx = createContext('ctx', 'test')
+      const props = { a: 1, b: '2' }
+      const child = <component name="child" />
+      const style: Style = { display: 'FLEX' }
+      const component = (
+        <StyledDefaultComponent name="test" context={ctx} id="id" properties={props} style={style}>
+          {child}
+        </StyledDefaultComponent>
+      )
+      expect(component).toEqual((
+        <component name="test" namespace={coreNamespace} context={ctx} id="id" properties={{ ...props, style }}>
+          {child}
+        </component>
+      ))
+    })
+  })
+})

--- a/components/__tests__/tsconfig.json
+++ b/components/__tests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true,
+    "jsx": "react",
+    "reactNamespace": "BeagleJSX",
     "module": "commonjs",
     "target": "esnext",
     "moduleResolution": "node",

--- a/components/jest.config.js
+++ b/components/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.ts'],
   testEnvironment: 'node',
   testMatch: [
-    '**/?(*.)+(spec).ts',
+    '**/?(*.)+(spec).ts?(x)',
   ],
   moduleNameMapper: {
     '^@zup-it/beagle-backend-core$': '<rootDir>../core/src',

--- a/components/src/fragments/conditional-render.tsx
+++ b/components/src/fragments/conditional-render.tsx
@@ -51,25 +51,8 @@ const validateChild = (child?: JSX.Element) => {
  *
  * If you pass `id` or `style` to the component `If`, they will end up in the enclosing container that will be created.
  *
- * When `If` has only `Then` as a child, no enclosing Container is created and its id and style are used for rendering
- * the child of `Then`. We will try to combine every property, but if there are clashes, the child of `Then` takes
- * precedence.
- *
- * ```tsx
- * <If id="if-component" style={{ margin: 5, backgroundColor: '#000000' }} condition={isLoading}>
- *   <Then><Text id="text-component" style={{ padding: 10, backgroundColor: '#FFFFFF' }}>Loading...</Text></Then>
- * </If>
- * ```
- *
- * becomes:
- * ```tsx
- * <Text
- *   id="text-component"
- *   style={{ display: condition(isLoading, 'FLEX', 'NONE'), margin: 5, padding: 10, backgroundColor: '#FFFFFF' }}
- * >
- *   Loading...
- * </Text>
- * ```
+ * When `If` has only `Then` as a child, no enclosing Container is created and both the id and style of the If component
+ * are ignored.
  *
  * @category Component
  * @param props the component properties. See: {@link IfProps}
@@ -99,8 +82,6 @@ export const If: FC<IfProps> = ({ id, style, condition, children }) => {
     )
   }
 
-  if (style) set(thenComponent, 'properties.style', { ...style, ...thenComponent.properties?.style })
-  if (id && !thenComponent.id) thenComponent.id = id
   return thenComponent
 }
 


### PR DESCRIPTION
> review after #20 is accepted
### Alters the behavior of passing id and style when no Else is provided
It makes sense passing id and style when a Container is gonna be created to wrap the content. In this case, the id and style become properties of the Container. When no Container is created, i.e., when there's no else, it makes no sense to pass id and style, since the only component to end up in the final tree is the child of Then, which can declare its own id and style:

```tsx
<If>
  <Then>
    <Text id="my-text" style={{ margin: 10 }}>Hello</Text>
  </Then>
</If>
```

Becomes:
```tsx
<Text id="my-text" style={{ margin: 10, display: condition(isLoading, 'FLEX', 'NONE') }}>Hello</Text>
```

It makes no sense to accept id and style in the If component in this case. Before, we tried to merge the properties, but it wasn't working. Instead of refactoring it to work, I decided to remove this feature, since it's completely useless. Now, the id and style are ignored if only a Then component is provided to If.

### Tests
Implemented all missing tests for If, Then and Else components.